### PR TITLE
Add latest and closed issue slides

### DIFF
--- a/api/card.js
+++ b/api/card.js
@@ -3,7 +3,7 @@ const { esc } = require('../lib/helpers');
 const { gh } = require('../lib/github');
 const ALL_SLIDES = require('../slides');
 
-function pickSlide(user, repos, events, commits, slidesParam, overrideIdx) {
+function pickSlide(user, repos, events, commits, issues, slidesParam, overrideIdx) {
   let enabled = ALL_SLIDES;
   if (slidesParam) {
     const ids = slidesParam.split(',').map(s => s.trim()).filter(Boolean);
@@ -17,7 +17,7 @@ function pickSlide(user, repos, events, commits, slidesParam, overrideIdx) {
   const idx = (overrideIdx !== undefined && overrideIdx >= 0 && overrideIdx < enabled.length)
     ? overrideIdx
     : bucket % enabled.length;
-  return enabled[idx].fn(user, repos, events, commits);
+  return enabled[idx].fn(user, repos, events, commits, issues);
 }
 
 module.exports = async function handler(req, res) {
@@ -40,11 +40,18 @@ module.exports = async function handler(req, res) {
   const token = process.env.GITHUB_TOKEN || '';
   try {
     const base = 'https://api.github.com';
-    const [user, repos, events] = await Promise.all([
+    const [user, repos, events, openIssues, closedIssues] = await Promise.all([
       gh(`${base}/users/${username}`, token),
       gh(`${base}/users/${username}/repos?sort=updated&per_page=100`, token),
       gh(`${base}/users/${username}/events/public?per_page=100`, token),
+      gh(`${base}/search/issues?q=author:${encodeURIComponent(username)}+type:issue+state:open&sort=updated&order=desc&per_page=10`, token),
+      gh(`${base}/search/issues?q=author:${encodeURIComponent(username)}+type:issue+state:closed&sort=updated&order=desc&per_page=10`, token),
     ]);
+
+    const issues = {
+      open: Array.isArray(openIssues?.items) ? openIssues.items : [],
+      closed: Array.isArray(closedIssues?.items) ? closedIssues.items : [],
+    };
 
     const commits = [];
     const reposSorted = [...repos].sort((a, b) => new Date(b.pushed_at) - new Date(a.pushed_at));
@@ -78,7 +85,7 @@ module.exports = async function handler(req, res) {
 
     const overrideIdx = q._slide !== undefined ? parseInt(q._slide, 10) : undefined;
     const slidesParam = q.slides || '';
-    const svgOut = pickSlide(user, repos, events, commits, slidesParam, overrideIdx);
+    const svgOut = pickSlide(user, repos, events, commits, issues, slidesParam, overrideIdx);
     const isPreview = overrideIdx !== undefined;
     res.setHeader('Cache-Control', isPreview ? 'no-cache' : 's-maxage=600,stale-while-revalidate=60');
     return res.status(200).send(svgOut);

--- a/app.js
+++ b/app.js
@@ -14,6 +14,8 @@ const ALL_SLIDES = [
   { id:'age',       label:'account age' },
   { id:'forks',     label:'total forks' },
   { id:'issues',    label:'open issues' },
+  { id:'latestissues', label:'latest issues' },
+  { id:'closedissues', label:'closed issues' },
 ];
 
 // state

--- a/slides/closedissues.js
+++ b/slides/closedissues.js
@@ -1,0 +1,33 @@
+const { W, GH } = require('../lib/constants');
+const { T, svg } = require('../lib/svg');
+const { ago } = require('../lib/helpers');
+
+function repoName(issue) {
+  const full = issue.repository_url ? issue.repository_url.split('/').slice(-2).join('/') : '';
+  return full || issue.repository?.full_name || '?';
+}
+
+module.exports = {
+  id: 'closedissues',
+  fn: (user, repos, events, commits, issues) => {
+    const list = (issues?.closed || []).slice(0, 3);
+    let o = '';
+    if (!list.length) {
+      o += T(W / 2, 88, 'no closed issues found', 13, GH.sec, 400, 'middle');
+      o += T(W / 2, 108, 'closed public issues will appear here', 11, GH.mut, 400, 'middle');
+      return svg(o);
+    }
+
+    list.forEach((issue, i) => {
+      const ry = 8 + i * 60;
+      const title = String(issue.title || 'untitled issue').slice(0, 56);
+      o += `<rect x="8" y="${ry}" width="${W - 16}" height="52" rx="6" fill="${GH.card}" stroke="${GH.border}" stroke-width="1"/>`;
+      o += `<circle cx="20" cy="${ry + 20}" r="5" fill="${GH.purple}"/>`;
+      o += T(32, ry + 22, title, 12, GH.text, 600);
+      o += T(32, ry + 38, `#${issue.number} in ${repoName(issue)}`.slice(0, 62), 10, GH.blue);
+      o += T(W - 14, ry + 22, ago(issue.closed_at || issue.updated_at), 10, GH.mut, 400, 'end');
+    });
+
+    return svg(o);
+  },
+};

--- a/slides/index.js
+++ b/slides/index.js
@@ -14,4 +14,6 @@ module.exports = [
   require('./age'),
   require('./forks'),
   require('./issues'),
+  require('./latestissues'),
+  require('./closedissues'),
 ];

--- a/slides/latestissues.js
+++ b/slides/latestissues.js
@@ -1,0 +1,33 @@
+const { W, GH } = require('../lib/constants');
+const { T, svg } = require('../lib/svg');
+const { ago } = require('../lib/helpers');
+
+function repoName(issue) {
+  const full = issue.repository_url ? issue.repository_url.split('/').slice(-2).join('/') : '';
+  return full || issue.repository?.full_name || '?';
+}
+
+module.exports = {
+  id: 'latestissues',
+  fn: (user, repos, events, commits, issues) => {
+    const list = (issues?.open || []).slice(0, 3);
+    let o = '';
+    if (!list.length) {
+      o += T(W / 2, 88, 'no open issues found', 13, GH.sec, 400, 'middle');
+      o += T(W / 2, 108, 'create or comment on public issues to populate this slide', 11, GH.mut, 400, 'middle');
+      return svg(o);
+    }
+
+    list.forEach((issue, i) => {
+      const ry = 8 + i * 60;
+      const title = String(issue.title || 'untitled issue').slice(0, 56);
+      o += `<rect x="8" y="${ry}" width="${W - 16}" height="52" rx="6" fill="${GH.card}" stroke="${GH.border}" stroke-width="1"/>`;
+      o += `<circle cx="20" cy="${ry + 20}" r="5" fill="${GH.green}"/>`;
+      o += T(32, ry + 22, title, 12, GH.text, 600);
+      o += T(32, ry + 38, `#${issue.number} in ${repoName(issue)}`.slice(0, 62), 10, GH.blue);
+      o += T(W - 14, ry + 22, ago(issue.updated_at || issue.created_at), 10, GH.mut, 400, 'end');
+    });
+
+    return svg(o);
+  },
+};


### PR DESCRIPTION
### Motivation
- Provide additional issue-focused slides so the SVG profile card can show the user's most recent open issues and recently closed issues.
- Surface issue activity (title, repo, number, relative time) alongside existing repo/commit/event slides for richer README embeds.

### Description
- Add two new slide modules `slides/latestissues.js` and `slides/closedissues.js` that render up to 3 open and 3 closed issues respectively, showing title, repo/number, and relative time.
- Extend the API data fetch in `api/card.js` to call the GitHub Search API for open and closed issues, assemble an `issues` object, and pass it into the slide selection pipeline by updating `pickSlide`'s parameters.
- Register both new slides in `slides/index.js` so they participate in rotation and `slides=` filtering, and add their IDs to the preview UI list in `app.js` so they can be toggled and previewed.

### Testing
- Ran syntax checks with `node --check api/card.js app.js slides/latestissues.js slides/closedissues.js` and they passed.
- Verified slides registry and presence with `node -e "const slides=require('./slides'); console.log(slides.map(s=>s.id).slice(-4).join(','));"` which printed the new slide ids.
- Rendered both new slide functions with mock issue data using a short Node script and confirmed SVG output was produced.
- Performed a UI smoke run by serving the preview page and capturing a headless screenshot with Playwright to validate the new slide entries appear in the preview list, noting that a static file server does not provide the serverless `api/card` endpoint (requests to `/api/card` returned 404 in that static-server smoke).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b6138b1c8331baea7404f32c405f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new slides displaying your latest open issues and closed issues on your profile card
  * Integrated GitHub issue data retrieval to showcase issue activity and history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->