### PR TITLE
Add dual badge support for independent slide selections

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,9 +18,10 @@ const ALL_SLIDES = [
   { id:'closedissues', label:'closed issues' },
 ];
 
-// state
-const enabled = new Set(ALL_SLIDES.map(s => s.id));
-let previewSlideIdx = 0; // index within enabled list currently previewed
+// two independent enabled sets
+const enabled1 = new Set(ALL_SLIDES.map(s => s.id));
+const enabled2 = new Set(ALL_SLIDES.map(s => s.id));
+let previewSlideIdx = 0;
 
 // ── build sidebar slide list ──
 const listEl = document.getElementById('slide-list');
@@ -32,7 +33,12 @@ ALL_SLIDES.forEach((s, i) => {
     `<span class="slide-idx">${i}</span>`
     + `<span class="slide-label" id="lbl-${s.id}">${s.label}</span>`
     + `<label class="toggle slide-toggle" onclick="event.stopPropagation();">`
-    +   `<input type="checkbox" id="chk-${s.id}" checked onchange="onToggle('${s.id}')">`
+    +   `<input type="checkbox" id="chk1-${s.id}" checked onchange="onToggle(1,'${s.id}')">`
+    +   `<span class="toggle-track"></span>`
+    +   `<span class="toggle-thumb"></span>`
+    + `</label>`
+    + `<label class="toggle slide-toggle" onclick="event.stopPropagation();">`
+    +   `<input type="checkbox" id="chk2-${s.id}" checked onchange="onToggle(2,'${s.id}')">`
     +   `<span class="toggle-track"></span>`
     +   `<span class="toggle-thumb"></span>`
     + `</label>`;
@@ -43,14 +49,17 @@ ALL_SLIDES.forEach((s, i) => {
   listEl.appendChild(row);
 });
 
+function getSet(n) { return n === 1 ? enabled1 : enabled2; }
+
 function updateCount() {
-  document.getElementById('enabled-count').textContent = '(' + enabled.size + ' / ' + ALL_SLIDES.length + ')';
+  document.getElementById('enabled-count').textContent = '(1: ' + enabled1.size + ' / 2: ' + enabled2.size + ')';
 }
 updateCount();
 
-function onToggle(id) {
-  const chk = document.getElementById('chk-' + id);
-  if (chk.checked) enabled.add(id); else enabled.delete(id);
+function onToggle(badge, id) {
+  const chk = document.getElementById('chk' + badge + '-' + id);
+  const set = getSet(badge);
+  if (chk.checked) set.add(id); else set.delete(id);
   updateCount();
   updateSnippets();
 }
@@ -59,9 +68,11 @@ let allOn = true;
 function toggleAll() {
   allOn = !allOn;
   ALL_SLIDES.forEach(s => {
-    const chk = document.getElementById('chk-' + s.id);
-    chk.checked = allOn;
-    if (allOn) enabled.add(s.id); else enabled.delete(s.id);
+    [1, 2].forEach(b => {
+      const chk = document.getElementById('chk' + b + '-' + s.id);
+      chk.checked = allOn;
+      if (allOn) getSet(b).add(s.id); else getSet(b).delete(s.id);
+    });
   });
   updateCount();
   updateSnippets();
@@ -77,27 +88,36 @@ function setActiveRow(id) {
 }
 
 // ── URL builders ──
-function getEnabledIds() {
-  return ALL_SLIDES.filter(s => enabled.has(s.id)).map(s => s.id);
+function getEnabledIds(badge) {
+  const set = badge ? getSet(badge) : enabled1;
+  return ALL_SLIDES.filter(s => set.has(s.id)).map(s => s.id);
 }
-function cardUrl({ slideIdx, preview } = {}) {
+
+function cardUrl({ slideIdx, preview, badge } = {}) {
   const u = document.getElementById('uname').value.trim();
   if (!u) return null;
   let url = `/api/card?user=${encodeURIComponent(u)}`;
-  const ids = getEnabledIds();
+  const ids = getEnabledIds(badge || 1);
   if (ids.length && ids.length < ALL_SLIDES.length) url += '&slides=' + ids.join(',');
   if (preview && slideIdx !== undefined) url += `&_slide=${slideIdx}&_t=${Date.now()}`;
   return url;
 }
 
-function updateSnippets() {
+function buildEmbedUrl(badge) {
   const u = document.getElementById('uname').value.trim() || 'username';
   const base = location.origin;
   let url = `${base}/api/card?user=${u}`;
-  const ids = getEnabledIds();
+  const ids = getEnabledIds(badge);
   if (ids.length && ids.length < ALL_SLIDES.length) url += '&slides=' + ids.join(',');
-  document.getElementById('snip-md').textContent   = `![GitHub Stats](${url})`;
-  document.getElementById('snip-html').textContent = `<img src="${url}" width="495" alt="GitHub Stats"/>`;
+  return url;
+}
+
+function updateSnippets() {
+  [1, 2].forEach(b => {
+    const url = buildEmbedUrl(b);
+    document.getElementById('snip-md-' + b).textContent   = `![GitHub Stats](${url})`;
+    document.getElementById('snip-html-' + b).textContent = `<img src="${url}" width="495" alt="GitHub Stats"/>`;
+  });
 }
 
 function doLoad(url, slideId) {
@@ -114,32 +134,32 @@ function doLoad(url, slideId) {
 
 // load card without preview override (server picks current bucket)
 function load() {
-  const enabledList = getEnabledIds();
+  const enabledList = getEnabledIds(1);
   if (!enabledList.length) return;
   const bucket = Math.floor(Date.now() / (10*60*1000));
   const idx = bucket % enabledList.length;
   previewSlideIdx = idx;
-  const url = cardUrl({ slideIdx: idx, preview: true });
+  const url = cardUrl({ slideIdx: idx, preview: true, badge: 1 });
   doLoad(url, enabledList[idx]);
 }
 
 // cycle to next slide
 function refresh() {
-  const enabledList = getEnabledIds();
+  const enabledList = getEnabledIds(1);
   if (!enabledList.length) return;
   previewSlideIdx = (previewSlideIdx + 1) % enabledList.length;
-  const url = cardUrl({ slideIdx: previewSlideIdx, preview: true });
+  const url = cardUrl({ slideIdx: previewSlideIdx, preview: true, badge: 1 });
   doLoad(url, enabledList[previewSlideIdx]);
 }
 
 // preview a specific slide by id
 function previewSlide(id) {
-  if (!enabled.has(id)) return;
-  const enabledList = getEnabledIds();
+  if (!enabled1.has(id) && !enabled2.has(id)) return;
+  const enabledList = getEnabledIds(1);
   const idx = enabledList.indexOf(id);
   if (idx < 0) return;
   previewSlideIdx = idx;
-  const url = cardUrl({ slideIdx: idx, preview: true });
+  const url = cardUrl({ slideIdx: idx, preview: true, badge: 1 });
   doLoad(url, id);
 }
 

--- a/index.html
+++ b/index.html
@@ -64,20 +64,38 @@
         </div>
       </div>
 
-      <!-- embed -->
+      <!-- embed 1 -->
       <div class="box">
-        <div class="box-header">Embed in README</div>
+        <div class="box-header">Embed in README 1</div>
         <div class="box-body">
           <div class="field-label">Markdown</div>
           <div class="field-note">Paste into your README.md</div>
           <div class="snippet-wrap">
-            <div class="code-block" id="snip-md"></div>
-            <button class="copy-btn" id="copy-md" onclick="doCopy('md')">copy</button>
+            <div class="code-block" id="snip-md-1"></div>
+            <button class="copy-btn" id="copy-md-1" onclick="doCopy('md-1')">copy</button>
           </div>
           <div class="field-label" style="margin-top:12px;">HTML <span style="font-weight:400;color:var(--fg-muted)">(width control)</span></div>
           <div class="snippet-wrap">
-            <div class="code-block" id="snip-html"></div>
-            <button class="copy-btn" id="copy-html" onclick="doCopy('html')">copy</button>
+            <div class="code-block" id="snip-html-1"></div>
+            <button class="copy-btn" id="copy-html-1" onclick="doCopy('html-1')">copy</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- embed 2 -->
+      <div class="box">
+        <div class="box-header">Embed in README 2</div>
+        <div class="box-body">
+          <div class="field-label">Markdown</div>
+          <div class="field-note">Paste into your README.md</div>
+          <div class="snippet-wrap">
+            <div class="code-block" id="snip-md-2"></div>
+            <button class="copy-btn" id="copy-md-2" onclick="doCopy('md-2')">copy</button>
+          </div>
+          <div class="field-label" style="margin-top:12px;">HTML <span style="font-weight:400;color:var(--fg-muted)">(width control)</span></div>
+          <div class="snippet-wrap">
+            <div class="code-block" id="snip-html-2"></div>
+            <button class="copy-btn" id="copy-html-2" onclick="doCopy('html-2')">copy</button>
           </div>
         </div>
       </div>
@@ -103,6 +121,11 @@
         <div class="box-header">
           <span>Slides <span id="enabled-count" style="font-weight:400;color:var(--fg-muted);font-size:13px;"></span></span>
           <button class="btn btn-default btn-sm" onclick="toggleAll()">toggle all</button>
+        </div>
+        <div class="slide-col-header">
+          <span class="slide-col-spacer"></span>
+          <span class="slide-col-label">1</span>
+          <span class="slide-col-label">2</span>
         </div>
         <div id="slide-list"></div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -107,5 +107,10 @@ select.gh-input{cursor:pointer;}
 .param-table td:first-child{font-family:ui-monospace,monospace;font-size:12px;color:var(--done);white-space:nowrap;width:100px;}
 .param-table td:last-child{color:var(--fg-muted);}
 
+/* slide column header (badge 1 / 2 labels) */
+.slide-col-header{display:flex;align-items:center;padding:4px 16px;border-bottom:1px solid var(--bd-muted);font-size:11px;font-weight:600;color:var(--fg-muted);}
+.slide-col-spacer{flex:1;}
+.slide-col-label{width:28px;text-align:center;flex-shrink:0;margin-left:8px;}
+
 .field-label{font-size:13px;font-weight:600;margin-bottom:2px;}
 .field-note{font-size:12px;color:var(--fg-muted);margin-bottom:4px;}


### PR DESCRIPTION
## Description
This change adds support for two independent badge configurations, allowing users to create and customize two separate GitHub Stats cards with different slide selections. Each badge (1 and 2) maintains its own enabled/disabled state for slides, and generates independent embed snippets.

### Key Changes:
- Split single `enabled` Set into `enabled1` and `enabled2` to track independent slide selections
- Updated UI to display dual toggle switches per slide (one for each badge)
- Added badge parameter throughout the codebase to distinguish between the two configurations
- Duplicated embed snippet sections to show separate Markdown and HTML code for each badge
- Added visual column headers ("1" and "2") above the toggle switches for clarity
- Updated `onToggle()`, `toggleAll()`, `getEnabledIds()`, and `cardUrl()` functions to accept and use badge parameter
- Modified `updateSnippets()` to generate URLs for both badges independently

## Related Issue(s)
N/A

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing Performed
- [x] Verified dual toggle switches render correctly in slide list
- [x] Confirmed independent state management for enabled1 and enabled2 sets
- [x] Tested toggle all functionality updates both badge states
- [x] Verified embed snippets generate correctly for both badges
- [x] Confirmed enabled count display shows both badge counts

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] Changes are backward compatible with existing functionality
- [x] UI properly displays dual badge controls with clear labeling

https://claude.ai/code/session_01STBWK3jzpnJ6Yw2Vmg13ud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now maintain and generate two separate embed configurations simultaneously, each with independent slide selections.
  * Added ability to copy embed snippets for both sections separately.

* **UI Improvements**
  * Added column header labels in the sidebar to visually distinguish between the two embed sections.
  * Enhanced toggle controls with improved visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->