### PR TITLE
Add badge parameter support for slide selection

### DIFF
--- a/api/card.js
+++ b/api/card.js
@@ -3,7 +3,7 @@ const { esc } = require('../lib/helpers');
 const { gh } = require('../lib/github');
 const ALL_SLIDES = require('../slides');
 
-function pickSlide(user, repos, events, commits, issues, slidesParam, overrideIdx) {
+function pickSlide(user, repos, events, commits, issues, slidesParam, overrideIdx, badgeNum) {
   let enabled = ALL_SLIDES;
   if (slidesParam) {
     const ids = slidesParam.split(',').map(s => s.trim()).filter(Boolean);
@@ -14,9 +14,10 @@ function pickSlide(user, repos, events, commits, issues, slidesParam, overrideId
   }
 
   const bucket = Math.floor(Date.now() / (10 * 60 * 1000));
+  const offset = badgeNum === 2 ? Math.floor(enabled.length / 2) : 0;
   const idx = (overrideIdx !== undefined && overrideIdx >= 0 && overrideIdx < enabled.length)
     ? overrideIdx
-    : bucket % enabled.length;
+    : (bucket + offset) % enabled.length;
   return enabled[idx].fn(user, repos, events, commits, issues);
 }
 
@@ -85,7 +86,8 @@ module.exports = async function handler(req, res) {
 
     const overrideIdx = q._slide !== undefined ? parseInt(q._slide, 10) : undefined;
     const slidesParam = q.slides || '';
-    const svgOut = pickSlide(user, repos, events, commits, issues, slidesParam, overrideIdx);
+    const badgeNum = q.badge === '2' ? 2 : 1;
+    const svgOut = pickSlide(user, repos, events, commits, issues, slidesParam, overrideIdx, badgeNum);
     const isPreview = overrideIdx !== undefined;
     res.setHeader('Cache-Control', isPreview ? 'no-cache' : 's-maxage=600,stale-while-revalidate=60');
     return res.status(200).send(svgOut);

--- a/app.js
+++ b/app.js
@@ -96,8 +96,9 @@ function getEnabledIds(badge) {
 function cardUrl({ slideIdx, preview, badge } = {}) {
   const u = document.getElementById('uname').value.trim();
   if (!u) return null;
-  let url = `/api/card?user=${encodeURIComponent(u)}`;
-  const ids = getEnabledIds(badge || 1);
+  const b = badge || 1;
+  let url = `/api/card?user=${encodeURIComponent(u)}&badge=${b}`;
+  const ids = getEnabledIds(b);
   if (ids.length && ids.length < ALL_SLIDES.length) url += '&slides=' + ids.join(',');
   if (preview && slideIdx !== undefined) url += `&_slide=${slideIdx}&_t=${Date.now()}`;
   return url;
@@ -106,7 +107,7 @@ function cardUrl({ slideIdx, preview, badge } = {}) {
 function buildEmbedUrl(badge) {
   const u = document.getElementById('uname').value.trim() || 'username';
   const base = location.origin;
-  let url = `${base}/api/card?user=${u}`;
+  let url = `${base}/api/card?user=${u}&badge=${badge}`;
   const ids = getEnabledIds(badge);
   if (ids.length && ids.length < ALL_SLIDES.length) url += '&slides=' + ids.join(',');
   return url;


### PR DESCRIPTION
## Description
This change adds support for a `badge` query parameter that allows different badge instances to display different slides. When `badge=2` is specified, the slide selection algorithm uses an offset equal to half the number of enabled slides, effectively creating a separate rotation cycle for the second badge.

The changes include:
- Modified `pickSlide()` function to accept a `badgeNum` parameter and apply an offset to the slide index calculation when `badgeNum === 2`
- Updated API endpoint to extract the `badge` query parameter and pass it to `pickSlide()`
- Updated frontend URL builders (`cardUrl()` and `buildEmbedUrl()`) to include the `badge` parameter in generated API URLs

This enables users to embed multiple badges on the same page that will show different slides in their rotation cycles.

## Related Issue(s)
Resolves #

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Technical Debt

## Testing Performed
- [x] Verified API endpoint correctly extracts and passes badge parameter
- [x] Confirmed slide offset calculation works correctly for badge=2
- [x] Tested URL generation in frontend for both single and multiple badges

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md, etc.)
- [x] My changes generate no new warnings or errors in the CI pipeline

https://claude.ai/code/session_01FFYRUUK3SVZ6DWdz14d6iG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Badge parameter is now explicitly handled throughout slide selection and URL generation, ensuring consistent badge-based scoping for card and embed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->