### PR TITLE
Center preview slides with consistent spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,10 +52,10 @@ body{background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSyst
 .box-body{padding:16px;}
 
 /* preview */
-.preview-area{background:var(--bg-inset);border-radius:4px;min-height:195px;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden;
+.preview-area{background:var(--bg-inset);border-radius:4px;min-height:195px;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden;padding:16px;box-sizing:border-box;
   background-image:linear-gradient(45deg,#1c2128 25%,transparent 25%),linear-gradient(-45deg,#1c2128 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#1c2128 75%),linear-gradient(-45deg,transparent 75%,#1c2128 75%);
   background-size:20px 20px;background-position:0 0,0 10px,10px -10px,-10px 0;}
-.preview-area img{width:100%;max-width:495px;display:block;position:relative;z-index:1;}
+.preview-area img{width:auto;max-width:100%;max-height:100%;display:block;position:relative;z-index:1;object-fit:contain;}
 .loading-overlay{position:absolute;inset:0;background:rgba(1,4,9,.7);display:flex;align-items:center;justify-content:center;z-index:2;opacity:0;pointer-events:none;transition:opacity .15s;}
 .preview-area.loading .loading-overlay{opacity:1;}
 .spinner{width:22px;height:22px;border:2px solid var(--bd);border-top-color:var(--blue);border-radius:50%;animation:spin .7s linear infinite;}


### PR DESCRIPTION
### Motivation
- Ensure previewed SVG slides are visually centered with identical horizontal and vertical spacing and do not stretch inside the preview pane.

### Description
- Modify `styles.css` so `.preview-area` uses `padding: 16px` and `box-sizing: border-box`, and update `.preview-area img` to `width: auto; max-width: 100%; max-height: 100%; object-fit: contain;` so images remain centered and uniformly spaced.

### Testing
- Launched a local static server with `python3 -m http.server 4173` and captured a Playwright screenshot of `http://127.0.0.1:4173` which confirmed the updated preview layout; note the static server does not provide `/api/card` so API calls returned `404` during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84ac9c93083318f52c13f18750162)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved preview area layout with enhanced internal spacing.
  * Updated image scaling for better responsive behavior and proper containment within the preview area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->