### PR TITLE
Center stat slide elements and improve preview image scaling

### DIFF
--- a/slides/stat.js
+++ b/slides/stat.js
@@ -4,7 +4,7 @@ const { T, svg } = require('../lib/svg');
 
 function slideStat(value, label, color) {
   const cx = W / 2;
-  const cy = H / 2 - 12;
+  const cy = H / 2;
   let o = '';
   o += `<circle cx="${cx}" cy="${cy}" r="78" fill="${color}" opacity="0.04"/>`;
   o += `<circle cx="${cx}" cy="${cy}" r="50" fill="${color}" opacity="0.05"/>`;

--- a/styles.css
+++ b/styles.css
@@ -52,10 +52,10 @@ body{background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSyst
 .box-body{padding:16px;}
 
 /* preview */
-.preview-area{background:var(--bg-inset);border-radius:4px;min-height:195px;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden;
+.preview-area{background:var(--bg-inset);border-radius:4px;min-height:195px;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden;padding:16px;box-sizing:border-box;
   background-image:linear-gradient(45deg,#1c2128 25%,transparent 25%),linear-gradient(-45deg,#1c2128 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#1c2128 75%),linear-gradient(-45deg,transparent 75%,#1c2128 75%);
   background-size:20px 20px;background-position:0 0,0 10px,10px -10px,-10px 0;}
-.preview-area img{width:100%;max-width:495px;display:block;position:relative;z-index:1;}
+.preview-area img{width:auto;max-width:100%;max-height:100%;display:block;position:relative;z-index:1;object-fit:contain;}
 .loading-overlay{position:absolute;inset:0;background:rgba(1,4,9,.7);display:flex;align-items:center;justify-content:center;z-index:2;opacity:0;pointer-events:none;transition:opacity .15s;}
 .preview-area.loading .loading-overlay{opacity:1;}
 .spinner{width:22px;height:22px;border:2px solid var(--bd);border-top-color:var(--blue);border-radius:50%;animation:spin .7s linear infinite;}


### PR DESCRIPTION
### Motivation
- Fix vertical alignment of the stat slide so circles and labels are properly centered.
- Prevent preview images from overflowing and ensure they preserve aspect ratio inside the preview area.

### Description
- Updated `slideStat` to set `cy` to `H / 2` (removed the `- 12` offset) to vertically center the circle and text.
- Added `padding:16px` and `box-sizing:border-box` to `.preview-area` to provide consistent inner spacing.
- Changed `.preview-area img` sizing to `width:auto; max-width:100%; max-height:100%; object-fit:contain` to maintain aspect ratio and avoid cropping.
- Minor CSS formatting adjustments in `styles.css`.

### Testing
- Ran `npm test` and all unit tests passed.
- Ran `npm run lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84ac9c93083318f52c13f18750162)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical positioning of stat visuals to achieve better visual centering and alignment on screen.
  * Enhanced preview area layout with improved spacing and padding adjustments for a cleaner visual appearance.
  * Updated image scaling behavior to use contained sizing instead of fill-based scaling, ensuring images maintain proper proportions while respecting their dimension limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->