### PR TITLE
docs: clarify Vercel slug naming and correct clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Install these dependencies before local development:
 
 ```bash
 # 1) Clone repository
-git clone https://github.com/readme-SVG/readme-SVG-profile-bento.git
-cd readme-SVG-profile-bento
+git clone https://github.com/readme-SVG/readme-SVG-profile-bengo.git
+cd readme-SVG-profile-bengo
 
 # 2) Install Python dependencies (for workflow script tooling)
 python -m venv .venv
@@ -157,6 +157,14 @@ vercel --prod
 
 - Function timeout for `api/card.js` (`maxDuration: 10`).
 - CORS headers for `/api/*` GET endpoints.
+
+If Vercel import/deploy fails with a project-name validation error, set a lowercase slug explicitly, for example:
+
+```bash
+vercel link --project readme-svg-profile-bengo
+```
+
+Vercel project slugs are safest in lowercase letters, numbers, and hyphens only.
 
 ### CI/CD Notes
 


### PR DESCRIPTION
### Motivation
- The repository README referenced the wrong clone path and lacked guidance to avoid Vercel project-name validation errors caused by uppercase characters in the project name.

### Description
- Update `README.md` to correct the clone URL to `readme-SVG-profile-bengo` and add a deployment note recommending lowercase Vercel project slugs with the example command `vercel link --project readme-svg-profile-bengo`.

### Testing
- Ran the automated find-and-replace script that updated `README.md` and inspected the resulting diff to confirm the clone URL and deployment note were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24e344e588331aae767494aeb13b8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local setup instructions with the correct repository name
  * Enhanced Vercel deployment guidance with steps for handling project-name validation errors
  * Clarified Vercel project slug naming requirements (lowercase letters, numbers, and hyphens only)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->